### PR TITLE
Exit on error from git clone

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -71,7 +71,7 @@ install)
 		echo "Using existing repo: $REPO_NAME"
 	else
 		echo "Cloning repo from GitHub to $REPO_NAME"
-		git clone "$REPO_HOME" "$REPO_NAME"
+		git clone "$REPO_HOME" "$REPO_NAME" || exit
 	fi
 	cd "$REPO_NAME"
 	git pull


### PR DESCRIPTION
Might want to add a word of advice to the novice user, but at least this spew is avoided if we just exit when git cannot clone:

bash gitflow-installer.sh install stable
### git-flow no-make installer

Installing git-flow to /usr/local/bin
Cloning repo from GitHub to gitflow
Cloning into 'gitflow'...
fatal: unable to access 'https://github.com/petervanderdoes/gitflow-avh.git/': SSL certificate problem: unable to get local issuer certificate
gitflow-installer.sh: line 76: cd: gitflow: No such file or directory
fatal: Not a git repository (or any of the parent directories): .git
gitflow-installer.sh: line 81: cd: gitflow: No such file or directory
fatal: Not a git repository (or any of the parent directories): .git
install: cannot stat 'gitflow/git-flow': No such file or directory
install: cannot stat 'gitflow/git-flow-init': No such file or directory
install: cannot stat 'gitflow/git-flow-feature': No such file or directory
install: cannot stat 'gitflow/git-flow-bugfix': No such file or directory
install: cannot stat 'gitflow/git-flow-hotfix': No such file or directory
install: cannot stat 'gitflow/git-flow-release': No such file or directory
install: cannot stat 'gitflow/git-flow-support': No such file or directory
install: cannot stat 'gitflow/git-flow-version': No such file or directory
install: cannot stat 'gitflow/gitflow-common': No such file or directory
install: cannot stat 'gitflow/gitflow-shFlags': No such file or directory
install: cannot stat 'gitflow/git-flow-config': No such file or directory
install: cannot stat 'gitflow/hooks/*': No such file or directory
