### PR TITLE
gitflow-shFlags boolean flag cannot be parsed/defined using compound expression

### DIFF
--- a/gitflow-shFlags
+++ b/gitflow-shFlags
@@ -356,9 +356,10 @@ _flags_define()
 	# append flag names to name lists
 	__flags_shortNames="${__flags_shortNames}${_flags_short_} "
 	__flags_longNames="${__flags_longNames}`_flags_removeExclamationName ${_flags_name_}` "
-	if [ ${_flags_type_} -eq ${__FLAGS_TYPE_BOOLEAN} \
-	  -a  ${_flags_isNegate_} -eq ${FLAGS_TRUE} ]; then
+	if [ ${_flags_type_} -eq ${__FLAGS_TYPE_BOOLEAN} ]; then
+	  if [ ${_flags_isNegate_} -eq ${FLAGS_TRUE} ]; then
 		__flags_boolNames="${__flags_boolNames}no${_flags_name_} "
+	  fi
 	fi
 
 	# append flag names to defined names for later validation checks


### PR DESCRIPTION
If no `DEFINE_boolean` precedes e.g. `DEFINE_string`, calling the latter yields:
`/usr/local/bin/gitflow-shFlags: line 359: [: too many arguments`

This due to empty `${_flags_isNegate_}` at line 359 of gitflow-shFlags.

The issue is hidden when a `DEFINE_boolean` is called before any other type.
(Only because `_flags_isNegate_` is not declared local?)

Fixed by splitting the expression into a nested test as was already done for the two following blocks.
