### PR TITLE
Convenience functions flag() and noflag() now handle embedded dash

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -76,8 +76,8 @@ startswith() { [ "$1" != "${1#$2}" ]; }
 endswith() { [ "$1" != "${1%$2}" ]; }
 
 # Convenience functions for checking shFlags flags
-flag() { local FLAG; eval FLAG='$FLAGS_'$1; [ $FLAG -eq $FLAGS_TRUE ]; }
-noflag() { local FLAG; eval FLAG='$FLAGS_'$1; [ $FLAG -ne $FLAGS_TRUE ]; }
+flag() { local FLAG; eval FLAG='$FLAGS_'$(_flags_underscoreName $1); [ $FLAG -eq $FLAGS_TRUE ]; }
+noflag() { local FLAG; eval FLAG='$FLAGS_'$(_flags_underscoreName $1); [ $FLAG -ne $FLAGS_TRUE ]; }
 
 # check_boolean
 # Check if given value can be interpreted as a boolean


### PR DESCRIPTION
Seen with `git flow release finish`
[...] `[: -master: integer expression expected`

Presumably none of these flags with an embedded dash ever tested true?!

```
$ grep "DEFINE_[a-z]*[[:space:]]*'[^']*-[^-]*'" -r gitflow/git*
gitflow/git-flow-bugfix:        DEFINE_boolean 'preserve-merges' false 'try to recreate merges while rebasing' p
gitflow/git-flow-bugfix:        DEFINE_boolean 'squash-info' false "add branch info during squash"
gitflow/git-flow-bugfix:        DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge "
gitflow/git-flow-bugfix:        DEFINE_boolean 'preserve-merges' false 'try to recreate merges' p
gitflow/git-flow-feature:       DEFINE_boolean 'preserve-merges' false 'try to recreate merges while rebasing' p
gitflow/git-flow-feature:       DEFINE_boolean 'squash-info' false "add branch info during squash"
gitflow/git-flow-feature:       DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge "
gitflow/git-flow-feature:       DEFINE_boolean 'preserve-merges' false 'try to recreate merges' p
gitflow/git-flow-hotfix:        DEFINE_boolean 'preserve-merges' false 'try to recreate merges' p
gitflow/git-flow-hotfix:        DEFINE_boolean 'squash-info' false "add branch info during squash"
gitflow/git-flow-release:       DEFINE_boolean 'squash-info' false "add branch info during squash"
gitflow/git-flow-release:       DEFINE_boolean 'ff-master' false "fast forward master branch if possible"
gitflow/git-flow-release:       DEFINE_boolean 'squash-info' false "add branch info during squash"
gitflow/git-flow-release:       DEFINE_boolean 'preserve-merges' false 'try to recreate merges' p
gitflow/git-flow-support:       DEFINE_boolean 'preserve-merges' false 'try to recreate merges' p
```

(Issue only tested on Cygwin.)
